### PR TITLE
fix(ci-cd): ajustar la obtención de mensajes de commit y la expresión…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Get all commit messages
         id: get_commit_messages
         run: |
-          commits=$(git log origin/main..HEAD --pretty=format:"%s%n%b" | head -n1)
+          commits=$(git log origin/main..HEAD --pretty=format:"%s")
           printf "MESSAGES<<EOF\n$commits\nEOF" >> $GITHUB_ENV
       - name: Check Conventional Commits
         run: |
-          regex="^(feat|fix|docs|style|refactor|test|build|ci|cd|perf|revert|chore|ui|ux|security|config|localization|hotfix|merge|env|wip|ci-test|data|prototype|a11y|deps|seo|db|analytics|types|mock|validation|rollback|infra|responsive|logging|migration|deprecate|cache|asset|backup|tracking|monitoring|script|scheduler|init)(\\([a-zA-Z0-9_-]+\\))?!?: [A-Za-z].{0,49}$"
+          regex="^(feat|fix|docs|style|refactor|test|build|ci|cd|perf|revert|chore|ui|ux|security|config|localization|hotfix|merge|env|wip|ci-test|data|prototype|a11y|deps|seo|db|analytics|types|mock|validation|rollback|infra|responsive|logging|migration|deprecate|cache|asset|backup|tracking|monitoring|script|scheduler|init)(\\([a-zA-Z0-9_-]+\\))?!?: .+"
           error=false
           count=0
           while IFS= read -r msg; do


### PR DESCRIPTION
### **User description**
… regular

- Modificado el comando para obtener solo el mensaje del último commit en lugar del cuerpo.
- Actualizada la expresión regular para permitir mensajes de commit más largos.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix commit message extraction to get only subject line

- Update regex pattern to allow longer commit messages


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Git log command"] --> B["Extract commit messages"]
  B --> C["Validate with regex pattern"]
  D["Updated regex"] --> C
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-cd.yml</strong><dd><code>Fix commit message extraction and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-cd.yml

<li>Modified git log command to extract only commit subject (<code>%s</code>) instead <br>of subject and body (<code>%s%n%b</code>)<br> <li> Updated regex pattern from <code>.{0,49}$</code> to <code>.+</code> to allow commit messages of <br>any length<br> <li> Removed <code>head -n1</code> command as it's no longer needed


</details>


  </td>
  <td><a href="https://github.com/ismahl95/Nuke-PowerPlant-Monitoring-System/pull/75/files#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>