### PR TITLE
Optimize GitHub Actions workflow with job consolidation and caching

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -125,6 +125,10 @@ jobs:
           name: jacoco-report
           path: backend/target/site/jacoco/
 
+      - name: Compile (needed for Sonar java binaries)
+        working-directory: backend
+        run: mvn -B -DskipTests clean compile
+
       - name: Analyze with SonarCloud
         working-directory: backend
         env:
@@ -133,7 +137,8 @@ jobs:
         run: |
           mvn -B sonar:sonar \
             -Dsonar.projectKey=ismahl95_Nuke-PowerPlant-Monitoring-System \
-            -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
+            -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml \
+            -Dsonar.java.binaries=target/classes
 
   # ── Deploy: solo en release, solo ismahl95, reutiliza el JAR ─────────────
   deploy:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,11 +11,9 @@ on:
 
 env:
   JAVA_VERSION: '17'
-  MAVEN_CACHE_KEY: ubuntu-latest-m2-cache-v1
-  SONAR_CACHE_KEY: ubuntu-latest-sonar-cache-v1
 
 jobs:
-  # Job para validar los mensajes de commit
+  # ── Validar mensajes de commit (solo en PRs) ──────────────────────────────
   commit-lint:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
@@ -50,133 +48,94 @@ jobs:
             exit 1
           fi
 
-  # Configuración de entorno
-  setup:
+  # ── CI: compile + test + jacoco (una sola ejecución de Maven) ────────────
+  ci:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'zulu'
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ env.MAVEN_CACHE_KEY }}
-          restore-keys: ubuntu-latest-m2-cache
 
-  # Job de pruebas
-  test:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'zulu'
+
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
           path: ~/.m2
-          key: ${{ env.MAVEN_CACHE_KEY }}
-          restore-keys: ubuntu-latest-m2-cache
-      - name: Run tests
-        run: mvn test
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2-
+
+      - name: Build, test and generate JaCoCo report
+        run: mvn clean verify
         working-directory: backend
 
-  # Job de build
-  build:
-    runs-on: ubuntu-latest
-    needs: [setup, test]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'zulu'
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ env.MAVEN_CACHE_KEY }}
-          restore-keys: ubuntu-latest-m2-cache
-      - name: Build with Maven
-        run: mvn clean install
-        working-directory: backend
-      # Listar archivos después de la construcción
-      - name: Listar archivos en backend/target
-        run: ls -l backend/target
-      # Renombrar JAR a app.jar
-      - name: Renombrar JAR a app.jar
+      - name: Rename JAR to app.jar
         run: cp backend/target/nuke-powerplant-back-*.jar backend/target/app.jar
 
-  # Job de cobertura de pruebas
-  jacoco:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up JDK
-        uses: actions/setup-java@v4
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v4
         with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'zulu'
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ env.MAVEN_CACHE_KEY }}
-          restore-keys: ubuntu-latest-m2-cache
-      - name: Generate JaCoCo coverage report
-        run: mvn clean test jacoco:report
-        working-directory: backend
-      - name: Upload JaCoCo report
+          name: app-jar
+          path: backend/target/app.jar
+          retention-days: 1
+
+      - name: Upload JaCoCo report artifact
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-report
           path: backend/target/site/jacoco/
+          retention-days: 1
 
-  # Job de análisis en SonarCloud
+  # ── SonarCloud: reutiliza el reporte JaCoCo ya generado ──────────────────
   sonarcloud:
     runs-on: ubuntu-latest
-    needs: jacoco
+    needs: ci
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # necesario para blame info de Sonar
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'zulu'
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ env.SONAR_CACHE_KEY }}
-          restore-keys: ubuntu-latest-sonar-cache
+
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
           path: ~/.m2
-          key: ${{ env.MAVEN_CACHE_KEY }}
-          restore-keys: ubuntu-latest-m2-cache
-      - name: Build and analyze with SonarCloud
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2-
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Download JaCoCo report
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-report
+          path: backend/target/site/jacoco/
+
+      - name: Analyze with SonarCloud
         working-directory: backend
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ismahl95_Nuke-PowerPlant-Monitoring-System
+        run: |
+          mvn -B sonar:sonar \
+            -Dsonar.projectKey=ismahl95_Nuke-PowerPlant-Monitoring-System \
+            -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
 
-  # Job de despliegue
+  # ── Deploy: solo en release, solo ismahl95, reutiliza el JAR ─────────────
   deploy:
     runs-on: ubuntu-latest
     needs: sonarcloud
@@ -185,25 +144,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Set up JDK
-        uses: actions/setup-java@v4
+      - name: Download JAR artifact
+        uses: actions/download-artifact@v4
         with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'zulu'
+          name: app-jar
+          path: backend/target/
 
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ env.MAVEN_CACHE_KEY }}
-          restore-keys: ubuntu-latest-m2-cache
-
-      # Ejecutar mvn clean install en el job de deploy
-      - name: Build with Maven (in deploy)
-        run: mvn clean install
-        working-directory: backend
-
-      # Log in to Docker Hub
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
This pull request significantly refactors the GitHub Actions CI/CD workflow by simplifying and consolidating jobs, improving artifact management, and optimizing cache usage. The main goal is to streamline the pipeline, reduce redundant steps, and ensure that build artifacts and coverage reports are reused efficiently across jobs.

**CI/CD Workflow Refactoring and Optimization:**

* Consolidated the separate `setup`, `test`, `build`, and `jacoco` jobs into a single `ci` job that handles compilation, testing, JaCoCo coverage report generation, and artifact uploading in one Maven execution.
* Updated artifact handling so that the JAR file and JaCoCo report are uploaded in the `ci` job and then downloaded in subsequent jobs (SonarCloud analysis and deploy), eliminating redundant builds and test executions. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L53-R138) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L188-L206)
* Improved cache keys for Maven and SonarCloud to be OS- and hash-based, ensuring more reliable and efficient caching.
* Updated the SonarCloud job to reuse the JaCoCo report artifact and removed redundant Maven build steps, passing the coverage report directly to SonarCloud analysis.
* Simplified the deploy job by removing unnecessary build steps and using the pre-built JAR artifact, further speeding up deployment.

**Other improvements:**

* Enhanced job and step naming for clarity and maintainability, and added comments to delineate workflow sections.
* Removed obsolete environment variables and cache keys that are no longer needed due to the new artifact and cache management strategy.